### PR TITLE
undefined method `intern' for :scss:Symbol (NoMethodError) on Ruby 1.8.7

### DIFF
--- a/lib/generators/bootstrap/install/install_generator.rb
+++ b/lib/generators/bootstrap/install/install_generator.rb
@@ -40,7 +40,7 @@ module Bootstrap
       end
 
       def create_assets
-        if options[:stylesheet_engine].intern == :css
+        if options[:stylesheet_engine].to_sym == :css
           stylesheet_extension = 'css'
         else
           stylesheet_extension = "css.#{options[:stylesheet_engine]}"


### PR DESCRIPTION
Hi there!

I was trying this out using ruby 1.8.7, and was getting this stack trace during `script/rails generate bootstrap:install`:

<pre><code>/Users/technicalpickles/.rvm/gems/ree-1.8.7-2011.03/gems/bootstrap-generators-1.0.1/lib/generators/bootstrap/install/install_generator.rb:43:in `create_assets': undefined method `intern' for :scss:Symbol (NoMethodError)
        from /Users/technicalpickles/.rvm/gems/ree-1.8.7-2011.03/gems/thor-0.14.6/lib/thor/task.rb:22:in `send'        from /Users/technicalpickles/.rvm/gems/ree-1.8.7-2011.03/gems/thor-0.14.6/lib/thor/task.rb:22:in `run'
        from /Users/technicalpickles/.rvm/gems/ree-1.8.7-2011.03/gems/thor-0.14.6/lib/thor/invocation.rb:118:in `invoke_task'
        from /Users/technicalpickles/.rvm/gems/ree-1.8.7-2011.03/gems/thor-0.14.6/lib/thor/invocation.rb:124:in `invoke_all'
        from /Users/technicalpickles/.rvm/gems/ree-1.8.7-2011.03/gems/thor-0.14.6/lib/thor/shell.rb:14:in `map'
        from /Users/technicalpickles/.rvm/gems/ree-1.8.7-2011.03/gems/thor-0.14.6/lib/thor/core_ext/ordered_hash.rb:75:in `each'
        from /Users/technicalpickles/.rvm/gems/ree-1.8.7-2011.03/gems/thor-0.14.6/lib/thor/invocation.rb:124:in `map'
        from /Users/technicalpickles/.rvm/gems/ree-1.8.7-2011.03/gems/thor-0.14.6/lib/thor/invocation.rb:124:in `invoke_all'
        from /Users/technicalpickles/.rvm/gems/ree-1.8.7-2011.03/gems/thor-0.14.6/lib/thor/group.rb:226:in `dispatch'        from /Users/technicalpickles/.rvm/gems/ree-1.8.7-2011.03/gems/thor-0.14.6/lib/thor/base.rb:389:in `start'
        from /Users/technicalpickles/.rvm/gems/ree-1.8.7-2011.03/gems/railties-3.1.1/lib/rails/generators.rb:168:in `invoke'        from /Users/technicalpickles/.rvm/gems/ree-1.8.7-2011.03/gems/railties-3.1.1/lib/rails/commands/generate.rb:12        from /Users/technicalpickles/.rvm/gems/ree-1.8.7-2011.03/gems/activesupport-3.1.1/lib/active_support/dependencies.rb:240:in `require'        from /Users/technicalpickles/.rvm/gems/ree-1.8.7-2011.03/gems/activesupport-3.1.1/lib/active_support/dependencies.rb:240:in `require'        from /Users/technicalpickles/.rvm/gems/ree-1.8.7-2011.03/gems/activesupport-3.1.1/lib/active_support/dependencies.rb:223:in `load_dependency'          from /Users/technicalpickles/.rvm/gems/ree-1.8.7-2011.03/gems/activesupport-3.1.1/lib/active_support/dependencies.rb:640:in `new_constants_in' 
        from /Users/technicalpickles/.rvm/gems/ree-1.8.7-2011.03/gems/activesupport-3.1.1/lib/active_support/dependencies.rb:223:in `load_dependency'  
        from /Users/technicalpickles/.rvm/gems/ree-1.8.7-2011.03/gems/activesupport-3.1.1/lib/active_support/dependencies.rb:240:in `require' 
        from /Users/technicalpickles/.rvm/gems/ree-1.8.7-2011.03/gems/railties-3.1.1/lib/rails/commands.rb:28</code></pre>


I did some research, and It looks like symbols don't have `.intern` before ruby 1.9. I did some testing, and it looks like `to_sym` is more portable across versions, so this pull request goes with that.

After applying that change, everything looks good :)
