### PR TITLE
Use force to update application layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Run bundle install:
 
 Get started:
 
-    rails generate bootstrap:install
+    rails generate bootstrap:install -f
 
 Once you've done that, any time you generate a controller or scaffold, you'll get [Bootstrap](http://twitter.github.com/bootstrap/) templates.
 


### PR DESCRIPTION
Instead of this:

``` shell
$ rails generate bootstrap:install
      create  lib/templates/erb
      create  lib/templates/erb/controller/view.html.erb
      create  lib/templates/erb/scaffold/edit.html.erb
      create  lib/templates/erb/scaffold/index.html.erb
      create  lib/templates/erb/scaffold/new.html.erb
      create  lib/templates/erb/scaffold/show.html.erb
      create  lib/templates/erb/scaffold/_form.html.erb
       exist  config
      create  config/initializers/simple_form.rb
      create  config/locales/simple_form.en.yml
    conflict  app/views/layouts/application.html.erb
Overwrite /home/gaurish/Dropbox/code/practice/splitcast/app/views/layouts/application.html.erb? (enter "h" for help) [Ynaqdh] y
       force  app/views/layouts/application.html.erb
      create  app/assets/stylesheets/bootstrap-variables.css.scss
      create  app/assets/stylesheets/bootstrap-generators.css.scss
      insert  app/assets/javascripts/application.js
```

its better to add a -f switch, so the user is not promoted about overwriting. Because to use bootstrap, they do need to overwrite `application.html.erb`. so `-f` makes sense

Btw, Thanks for creating this gem. its quite handy & rad! :+1: 
