### PR TITLE
Remove deprecated use of :confirm in scaffold templates

### DIFF
--- a/lib/generators/bootstrap/install/templates/lib/templates/erb/scaffold/index.html.erb
+++ b/lib/generators/bootstrap/install/templates/lib/templates/erb/scaffold/index.html.erb
@@ -26,7 +26,7 @@
 <% end -%>
       <td><%%= link_to 'Show', <%= singular_table_name %> %></td>
       <td><%%= link_to 'Edit', edit_<%= singular_table_name %>_path(<%= singular_table_name %>) %></td>
-      <td><%%= link_to 'Destroy', <%= singular_table_name %>, confirm: 'Are you sure?', method: :delete %></td>
+      <td><%%= link_to 'Destroy', <%= singular_table_name %>, data: { confirm: 'Are you sure?' }, method: :delete %></td>
     </tr>
 <%% end %>
   </tbody>

--- a/lib/generators/bootstrap/install/templates/lib/templates/haml/scaffold/index.html.haml
+++ b/lib/generators/bootstrap/install/templates/lib/templates/haml/scaffold/index.html.haml
@@ -22,4 +22,4 @@
 <% end -%>
         %td= link_to 'Show', <%= singular_table_name %>
         %td= link_to 'Edit', edit_<%= singular_table_name %>_path(<%= singular_table_name %>)
-        %td= link_to 'Destroy', <%= singular_table_name %>, :confirm => 'Are you sure?', :method => :delete
+        %td= link_to 'Destroy', <%= singular_table_name %>, :data => { confirm: 'Are you sure?' }, :method => :delete


### PR DESCRIPTION
The `:confirm` option has been deprecated and will be removed in Rails 4.1.

This changes all instances of `:confirm` in the scaffold templates from:

``` ruby
:confirm => 'Are you sure?'
```

to

``` ruby
:data => { confirm: 'Are you sure?' }
```

According to https://github.com/rails/rails/pull/6613 it was deprecated in rails 3.2
