### PR TITLE
Fix typo in haml starter template

### DIFF
--- a/lib/generators/bootstrap/install/templates/layouts/starter.html.haml
+++ b/lib/generators/bootstrap/install/templates/layouts/starter.html.haml
@@ -42,7 +42,7 @@
       - flash.each do |name, msg|
         = content_tag :div, :class => "alert alert-#{name == :error ? "danger" : "success" } alert-dismissable", :role => "alert" do
           %button.close{:type => "button", :data => {:dismiss => "alert"} }
-            span{:aria => {:hidden => "true"} } &times;
-            span.sr-only Close
+            %span{:aria => {:hidden => "true"} } &times;
+            %span.sr-only Close
           = msg
       = yield


### PR DESCRIPTION
both spans in the html starter template were missing the '%' prefix, causing them to display as escaped text.
