### PR TITLE
replaced symbols with strings for error in flash messages in starter …

### DIFF
--- a/lib/generators/bootstrap/install/templates/layouts/starter.html.erb
+++ b/lib/generators/bootstrap/install/templates/layouts/starter.html.erb
@@ -45,7 +45,7 @@
   </nav>
   <div class="container">
     <%% flash.each do |name, msg| %>
-      <%%= content_tag :div, class: "alert alert-#{ name == :error ? "danger" : "success" } alert-dismissable", role: "alert" do %>
+      <%%= content_tag :div, class: "alert alert-#{ name == "error" ? "danger" : "success" } alert-dismissable", role: "alert" do %>
         <button type="button" class="close" data-dismiss="alert"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
         <%%= msg %>
       <%% end %>

--- a/lib/generators/bootstrap/install/templates/layouts/starter.html.haml
+++ b/lib/generators/bootstrap/install/templates/layouts/starter.html.haml
@@ -40,7 +40,7 @@
               %a{href: "#contact"} Contact
     .container
       - flash.each do |name, msg|
-        = content_tag :div, class: "alert alert-#{name == :error ? "danger" : "success" } alert-dismissable", role: "alert" do
+        = content_tag :div, class: "alert alert-#{name == "error" ? "danger" : "success" } alert-dismissable", role: "alert" do
           %button.close{type: "button", data: {dismiss: "alert"} }
             %span{aria: {hidden: "true"} } &times;
             %span.sr-only Close

--- a/lib/generators/bootstrap/install/templates/layouts/starter.html.slim
+++ b/lib/generators/bootstrap/install/templates/layouts/starter.html.slim
@@ -43,7 +43,7 @@ html
                 | Contact
     .container
       - flash.each do |name, msg|
-        = content_tag :div, class: "alert alert-#{ name == :error ? "danger" : "success" } alert-dismissable", role: "alert" do
+        = content_tag :div, class: "alert alert-#{ name == "error" ? "danger" : "success" } alert-dismissable", role: "alert" do
           button.close type="button" data-dismiss="alert"
             span aria-hidden="true"
               | &times;


### PR DESCRIPTION
…templates

Can't really say why, but I needed to change this to work. Otherwise my flash messages were always green, also in case of error.