### PR TITLE
Pretty check_box

### DIFF
--- a/lib/generators/bootstrap/install/templates/form_builders/form_builder/_form.html.erb
+++ b/lib/generators/bootstrap/install/templates/form_builders/form_builder/_form.html.erb
@@ -14,10 +14,21 @@
 
 <% attributes.each do |attribute| -%>
   <div class="form-group">
-    <%%= f.label :<%= attribute.name %>, class: "col-sm-2 control-label" %>
-    <div class="col-sm-10">
-      <%%= f.<%= attribute.field_type %> :<%= attribute.name %>, class: "form-control" %>
-    </div>
+    <% if attribute.field_type == :check_box %>
+      <div class="col-sm-offset-2 col-sm-10"> 
+        <div class="checkbox">
+          <label>
+            <%%= f.<%= attribute.field_type %> :<%= attribute.name %> %>
+            <%= attribute.human_name %>      
+          </label>
+        </div>
+      </div>
+    <% else %>
+      <%%= f.label :<%= attribute.name %>, class: "col-sm-2 control-label" %>
+      <div class="col-sm-10">
+        <%%= f.<%= attribute.field_type %> :<%= attribute.name %>, class: "form-control" %>
+      </div>
+    <% end %>
   </div>
 <% end -%>
   <div class="form-group">


### PR DESCRIPTION
Any fields that are of the `:check_box` type now properly use bootstrap's checkbox styling. This commit is just for the html.erb template.

![screen shot 2015-10-06 at 2 51 28 pm](https://cloud.githubusercontent.com/assets/519728/10322302/5d4940ae-6c3a-11e5-834f-12f11b740b2e.png)
