### PR TITLE
Remove `content_tag_for` for Rails 5 compatibility

### DIFF
--- a/lib/generators/bootstrap/install/templates/lib/templates/erb/scaffold/index.html.erb
+++ b/lib/generators/bootstrap/install/templates/lib/templates/erb/scaffold/index.html.erb
@@ -20,13 +20,15 @@
     </thead>
 
     <tbody>
-      <%%= content_tag_for(:tr, @<%= plural_table_name %>) do |<%= singular_table_name %>| %>
-    <% attributes.each do |attribute| -%>
-        <td><%%= <%= singular_table_name %>.<%= attribute.name %> %></td>
-    <% end -%>
-        <td><%%= link_to 'Show', <%= singular_table_name %> %></td>
-        <td><%%= link_to 'Edit', edit_<%= singular_table_name %>_path(<%= singular_table_name %>) %></td>
-        <td><%%= link_to 'Destroy', <%= singular_table_name %>, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      <%% @<%= plural_table_name%>.each do |<%= singular_table_name %>| %>
+        <%%= content_tag :tr, id: dom_id(<%= singular_table_name %>), class: dom_class(<%= singular_table_name %>) do %>
+          <% attributes.each do |attribute| -%>
+            <td><%%= <%= singular_table_name %>.<%= attribute.name %> %></td>
+          <% end -%>
+          <td><%%= link_to 'Show', <%= singular_table_name %> %></td>
+          <td><%%= link_to 'Edit', edit_<%= singular_table_name %>_path(<%= singular_table_name %>) %></td>
+          <td><%%= link_to 'Destroy', <%= singular_table_name %>, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <%% end %>
       <%% end %>
     </tbody>
   </table>


### PR DESCRIPTION
`content_tag_for` was extracted to a separate gem for Rails 5. This commit fixes the dependency without having to add the new gem.

This fixes #43. 

I've tested this in Rails 5, but not other versions. The cloned tests are throwing errors about missing bootstrap files, so I can't say much about the tests for this other than "it works for my project."