### PR TITLE
Make assets.precompile compatible with Sprockets 4

### DIFF
--- a/lib/bootstrap-generators.rb
+++ b/lib/bootstrap-generators.rb
@@ -11,7 +11,7 @@ module Bootstrap
 
         app.config.assets.paths << ::Rails.root.join('app', 'assets', 'fonts')
 
-        app.config.assets.precompile << /\.(?:svg|eot|woff|woff2|ttf)$/
+        app.config.assets.precompile << ["*.svg", "*.eot", "*.woff", "*.woff2", "*.ttf"]
       end
     end
   end


### PR DESCRIPTION
See: https://github.com/rails/sprockets-rails/issues/269

Regex no longer supported in Sprockets