### PR TITLE
Load the glyphicons explicitly, without regex to support Sprockets 4

### DIFF
--- a/lib/bootstrap-generators.rb
+++ b/lib/bootstrap-generators.rb
@@ -11,7 +11,9 @@ module Bootstrap
 
         app.config.assets.paths << ::Rails.root.join('app', 'assets', 'fonts')
 
-        app.config.assets.precompile << /\.(?:svg|eot|woff|woff2|ttf)$/
+        %w(eot svg ttf woff woff2).each do |ext|
+          app.config.assets.precompile << "bootstrap/glyphicons-halflings-regular.#{ext}"
+        end
       end
     end
   end


### PR DESCRIPTION
See: https://github.com/decioferreira/bootstrap-generators/issues/50
See: https://github.com/rails/sprockets-rails/issues/269

Inspired by this fix: https://github.com/FortAwesome/font-awesome-sass/commit/b8dd32cf3bcd5d14c12543d767f8db68b31a6a9b

Regex no longer supported in Sprockets as of version 4

